### PR TITLE
Use the processed response body, rather than the raw response

### DIFF
--- a/lib/al_papi/http.rb
+++ b/lib/al_papi/http.rb
@@ -25,9 +25,9 @@ module AlPapi
       args = [http_verb, url]
       args << params if http_verb == 'post'
 
-      RestClient.send(*args) do |res, req, raw_res|
-        body = raw_res.body
-        code = raw_res.code.to_i
+      RestClient.send(*args) do |res|
+        body = res.body
+        code = res.code.to_i
 
         self.response = body
         self.errors   = []


### PR DESCRIPTION
Authlabs recently configured its servers to send gzip-encoded responses, which causes `AlPapi::Keyword.get` to return broken bodies. As far as I can see, there's really no reason to use the raw response rather than the normal response here.
