### PR TITLE
Handle gzip responses

### DIFF
--- a/lib/al_papi/http.rb
+++ b/lib/al_papi/http.rb
@@ -24,8 +24,8 @@ module AlPapi
       args = [http_verb, url]
       args << params if http_verb == 'post'
 
-      RestClient.send(*args) do |res, _req, raw_res|
-        body = raw_res.body
+      RestClient.send(*args) do |res|
+        body = res.body
         code = res.code.to_i
 
         self.response = body

--- a/spec/keywords_spec.rb
+++ b/spec/keywords_spec.rb
@@ -95,7 +95,7 @@ describe AlPapi::Keyword do
         expect(@res).to_not be_success
         expect(@res).to_not be_over_limit
         expect(@res).to_not be_suspended
-        expect(@res.body).to be_nil
+        expect(@res.body).to be_empty
         expect(@res.code).to eql 204
         expect(@res.path).to match '/keywords/get'
       end


### PR DESCRIPTION
closes #1

Use the parsed RestClient body instead of the raw body response
so gzip encoded responses are handled correctly.

cc: thanks @polgfred
